### PR TITLE
Adding on_change_type() on sale.line

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -185,6 +185,12 @@ class SaleLine(metaclass=PoolMeta):
         if self.unit_price is not None:
             self.update_prices()
 
+    @fields.depends('type', 'taxes')
+    def on_change_type(self):
+        if self.type != 'line':
+            self.gross_unit_price = None
+        super(SaleLine, self).on_change_type()
+
     def get_invoice_line(self):
         pool = Pool()
         InvoiceLine = pool.get('account.invoice.line')

--- a/sale.py
+++ b/sale.py
@@ -188,7 +188,9 @@ class SaleLine(metaclass=PoolMeta):
     @fields.depends('type', 'taxes')
     def on_change_type(self):
         if self.type != 'line':
+            self.discount = None
             self.gross_unit_price = None
+            self.update_prices()
         super(SaleLine, self).on_change_type()
 
     def get_invoice_line(self):


### PR DESCRIPTION
If you fill the fields of a line of type 'line', and then switch to another type, the gross_unit_price value needs to be cleared, as tryton does with product, unit and taxes in sale module, otherwise you can't change the state of the sale.
Also this problem comes from 6.8 so it will be great doing backports to older versions (I don't know if I can)